### PR TITLE
M32040: Missing word or tag

### DIFF
--- a/docs/Xamarin.Forms.PlatformConfiguration.GTKSpecific/BoxView.xml
+++ b/docs/Xamarin.Forms.PlatformConfiguration.GTKSpecific/BoxView.xml
@@ -59,7 +59,7 @@
         <Parameter Name="config" Type="Xamarin.Forms.IPlatformElementConfiguration&lt;Xamarin.Forms.PlatformConfiguration.GTK,Xamarin.Forms.BoxView&gt;" RefType="this" />
       </Parameters>
       <Docs>
-        <param name="config">The platform configuration for the box view element on the GTK platform whose <!-- missing word or tag --> to get.</param>
+        <param name="config">The platform configuration for the box view element on the GTK platform whose corner radius to get.</param>
         <summary>Returns a Boolean value that tells whether the box view has a corner radius set.</summary>
         <returns>A Boolean value that tells whether the box view has a corner radius set.</returns>
         <remarks>To be added.</remarks>


### PR DESCRIPTION
Hello, @MichaelNorman,  
Translator has reported possible source content issue. 
Description:´The tag is missing in the source (whose ? to set). For the time being we inserted "BoxView" because we did not want to deliver an incomplete sentence. Please advise
Please review the comment tag added and reply with explanation if fix is needed or not. If you make related fix in another PR then share your PR number so we can confirm and close this PR.
Many thanks in advance.