### PR TITLE
M32047: Possible wrong tag in source

### DIFF
--- a/docs/Xamarin.Forms/Rectangle.xml
+++ b/docs/Xamarin.Forms/Rectangle.xml
@@ -175,7 +175,7 @@
         <param name="pt">The  <see cref="T:Xamarin.Forms.Point" /> being checked for containment.</param>
         <summary>Whether the <paramref name="pt" /> is within, or along the periphery, of this <see cref="T:Xamarin.Forms.Rectangle" />.</summary>
         <returns>
-          <see langword="true" /> if <paramref name="pt" /> is within, or along the periphery, of <c>this<!-- is this word tagged correctly --> </c><see cref="T:Xamarin.Forms.Rectangle" />.</returns>
+          <see langword="true" /> if <paramref name="pt" /> is within, or along the periphery, of this <see cref="T:Xamarin.Forms.Rectangle" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>


### PR DESCRIPTION
Hello, @MichaelNorman, @lobrien,
Translator has reported possible source content issue. 
Description: Could it be possibe that "this" has been tagged wrongly and that it is just a normal word and not an element/classe/attribute?
Please review the comment tag added and reply with explanation if fix is needed or not. If you make related fix in another PR then share your PR number so we can confirm and close this PR.
Many thanks in advance.