### PR TITLE
Fixed extraneous '[' in documentation.

### DIFF
--- a/docs/Xamarin.Forms/ExportEffectAttribute.xml
+++ b/docs/Xamarin.Forms/ExportEffectAttribute.xml
@@ -23,12 +23,10 @@
       <para>Developers must supply a name that is unique over the scope of the value that was supplied to <see cref="T:Xamarin.Forms.ResolutionGroupNameAttribute" />. The <see cref="M:Xamarin.Forms.Effect.Resolve(System.String)" /> method takes a string that is the concatenation of the the resolution group name that was provided to <see cref="T:Xamarin.Forms.ResolutionGroupNameAttribute" />, '<c>.</c>', and the name that was supplied to <see cref="T:Xamarin.Forms.ExportEffectAttribute" />, and returns an effect that will have the type <paramref name="effectType" />.</para>
       <example>
         <para>For example, with the declarations:</para>
-        <code lang="c#"><![CDATA[
-        [assembly: ResolutionGroupName ("com.YourCompany")]
-        [assembly: ExportEffect (typeof (ShadowEffect), "ShadowEffect")]]]></code>
+        <code lang="C#"><![CDATA[[assembly: ResolutionGroupName ("com.YourCompany")]
+[assembly: ExportEffect (typeof (ShadowEffect), "ShadowEffect")]]]></code>
         <para>Then the code below will add the effect to a button:</para>
-        <code lang="c#"><![CDATA[
-        [var button = new Button { Text = "I have a shadow" };
+        <code lang="C#"><![CDATA[var button = new Button { Text = "I have a shadow" };
 button.Effects.Add (Effect.Resolve ("com.YourCompany.ShadowEffect"));]]></code>
       </example>
     </remarks>
@@ -58,12 +56,10 @@ button.Effects.Add (Effect.Resolve ("com.YourCompany.ShadowEffect"));]]></code>
           <para>Developers must supply a <paramref name="uniqueName" /> that is unique over the scope of the value that was supplied to <see cref="T:Xamarin.Forms.ResolutionGroupNameAttribute" />. The <see cref="M:Xamarin.Forms.Effect.Resolve(System.String)" /> method takes a string that is the concatenation of the the resolution group name that was provided to <see cref="T:Xamarin.Forms.ResolutionGroupNameAttribute" />, '<c>.</c>', and the name that was supplied to <see cref="T:Xamarin.Forms.ExportEffectAttribute" />, and returns an effect that will have the type <paramref name="effectType" />.</para>
           <example>
             <para>For example, with the declarations:</para>
-            <code lang="c#"><![CDATA[
-        [assembly: ResolutionGroupName ("com.YourCompany")]
-        [assembly: ExportEffect (typeof (ShadowEffect), "ShadowEffect")]]]></code>
+            <code lang="C#"><![CDATA[[assembly: ResolutionGroupName ("com.YourCompany")]
+[assembly: ExportEffect (typeof (ShadowEffect), "ShadowEffect")]]]></code>
             <para>Then the code below will add the effect to a button:</para>
-            <code lang="c#"><![CDATA[
-        [var button = new Button { Text = "I have a shadow" };
+            <code lang="C#"><![CDATA[var button = new Button { Text = "I have a shadow" };
 button.Effects.Add (Effect.Resolve ("com.YourCompany.ShadowEffect"));]]></code>
           </example>
         </remarks>


### PR DESCRIPTION
Fixed a few issues with the documentation of "ExportEffectAttribute".
 * Reindented the code blocks, and changed language from 'c#' to 'C#'
 * Removed an extraneous '[' from in front of "var button ..."