### PR TITLE
Typo fixed

### DIFF
--- a/docs/Xamarin.Forms/Command`1.xml
+++ b/docs/Xamarin.Forms/Command`1.xml
@@ -26,7 +26,7 @@
     <summary>Defines an <see cref="T:System.Windows.Input.ICommand" /> implementation wrapping a generic Action&lt;T&gt;.</summary>
     <remarks>
       <para>
-              The following example creates a new Command and set it to a button.
+              The following example creates a new Command and sets it to a button.
               </para>
       <example language="C#">
         <code lang="csharp lang-csharp"><![CDATA[


### PR DESCRIPTION
Missing a character from "... and set it to a button". Should be "... and set**s** it to a button".