### PR TITLE
VisualElement.IsTabStop updated

### DIFF
--- a/docs/Xamarin.Forms/VisualElement.xml
+++ b/docs/Xamarin.Forms/VisualElement.xml
@@ -1087,7 +1087,7 @@
       <Docs>
         <summary>Gets or sets a value that indicates whether this element is included in tab navigation. This is a bindable property.</summary>
         <value><see langword="true" /> if the element is included in tab navigation; otherwise, <see langword="false" />. Default value is <see langword="true" />.</value>
-        <remarks>Controlling the tab sequence with a combination of IsTabStop and <see cref="T:Xamarin.Forms.VisualElement.TabIndex" /> rather than using the default tab sequence is sometimes necessary in order to tune the keyboard accessibility of your UI. For more info, see <format type="text/html"><a href="https://docs.microsoft.com/en-us/xamarin/xamarin-forms/app-fundamentals/accessibility/keyboard">Keyboard Accessibility in Xamarin.Forms</a></format>.</remarks>
+        <remarks>Controlling the tab sequence with a combination of IsTabStop and <see cref="T:Xamarin.Forms.VisualElement.TabIndex" /> rather than using the default tab sequence is sometimes necessary in order to tune the keyboard accessibility of your UI. For more info, see <format type="text/html"><a href="https://docs.microsoft.com/xamarin/xamarin-forms/app-fundamentals/accessibility/keyboard">Keyboard Accessibility in Xamarin.Forms</a></format>.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsTabStopProperty">

--- a/docs/Xamarin.Forms/VisualElement.xml
+++ b/docs/Xamarin.Forms/VisualElement.xml
@@ -1085,9 +1085,9 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets or sets a value that indicates whether this element is included in tab navigation. This is a bindable property.</summary>
+        <value><see langword="true" /> if the element is included in tab navigation; otherwise, <see langword="false" />. Default value is <see langword="true" />.</value>
+        <remarks>Controlling the tab sequence with a combination of IsTabStop and <see cref="T:Xamarin.Forms.VisualElement.TabIndex" /> rather than using the default tab sequence is sometimes necessary in order to tune the keyboard accessibility of your UI. For more info, see <format type="text/html"><a href="https://docs.microsoft.com/en-us/xamarin/xamarin-forms/app-fundamentals/accessibility/keyboard">Keyboard Accessibility in Xamarin.Forms</a></format>.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsTabStopProperty">


### PR DESCRIPTION
Added the summary, value and remarks sections for the VisualElement.IsTabStop property. The remarks part is the same as in the [UWP documentation](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.control.istabstop), but it links to Xamarin specific resources.