### PR TITLE
Improved the Application class remarks

### DIFF
--- a/docs/Xamarin.Forms/Application.xml
+++ b/docs/Xamarin.Forms/Application.xml
@@ -28,7 +28,7 @@
     <remarks>
       <para>The <see cref="T:Xamarin.Forms.Application" /> class is the core of a Xamarin.Forms application. It sets the root page of the application, persists primitive type data across invocations of the application in the <see cref="P:Xamarin.Forms.Application.Properties" /> dictionary, and provides events to respond to pushing and popping of modal views. Visual studio creates this class for the developer in the appropriate project in a new Xamarin.Forms solution.</para>
       <example>
-        <para>Both Visual Studio for Mac and Visual Studio create a XAML file for the application when the developer creates a Xamarin.Forms solution. The following example code a typical <c>Application</c> class, with an entry in its resource dictionary, from such a XAML file.</para>
+        <para>Both Visual Studio for Mac and Visual Studio create a XAML and a code-behind file for the application when the developer creates a new Xamarin.Forms solution. The following example shows a typical <c>Application</c> class, with an entry in its resource dictionary.</para>
         <code lang="XAML"><![CDATA[
 <Application xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
@@ -37,6 +37,32 @@
      <Color x:Key="ButtonBackgroundColor">Red</Color>
   </Application.Resources>
 </Application>]]></code>
+        <code lang="csharp lang-csharp"><![CDATA[
+public partial class App : Application
+{
+    public App()
+    {
+        InitializeComponent();
+
+        MainPage = new MainPage();
+    }
+
+    protected override void OnStart()
+    {
+        // Handle when your app starts
+    }
+
+    protected override void OnSleep()
+    {
+        // Handle when your app sleeps
+    }
+
+    protected override void OnResume()
+    {
+        // Handle when your app resumes
+    }
+}
+        ]]></code>
       </example>
     </remarks>
   </Docs>


### PR DESCRIPTION
In the original version, it seems like the Application class can be defined purely in XAML but that's not the case. I think it's important to mention and show the code-behind file too. If the full class is too much, maybe the constructor could be shown fully with a comment below saying something like *"// OnStart, OnSleep, OnResume overrides omitted"*