### PR TITLE
add custom search scope

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -46,7 +46,7 @@
       "ms.author": "dotnetcontent",
       "manager": "crdun",
       "ms.date": "03/13/2019",
-      "searchScope": ["Xamarin"],
+      "searchScope": ["Xamarin.Forms API"],
       "uhfHeaderId": "MSDocsHeader-DotNet",
       "ms.topic": "managed-reference",
       "ms.prod": "xamarin",


### PR DESCRIPTION
joint search scope with all Xamarin docs makes it hard to search conceptual docs avoids API reference cluttering conceptual doc search results