### PR TITLE
Fixes incorrect documentation in remarks section

### DIFF
--- a/docs/Xamarin.Forms/BindingMode.xml
+++ b/docs/Xamarin.Forms/BindingMode.xml
@@ -38,7 +38,7 @@ label.BindingContext = viewmodel = new PersonViewModel ();
 label.SetBinding<PersonViewModel> (Label.TextProperty, vm => vm.Name, mode: BindingMode.OneWay);
     
 viewmodel.Name = "John Doe";
-Debug.WriteLine (label.Text); //prints "John Doe"
+Debug.WriteLine (label.Text); //prints ""
 label.Text = "Foo";
 Debug.WriteLine (viewmodel.Name); //prints "John Doe"
     
@@ -60,7 +60,7 @@ label.BindingContext = viewmodel = new PersonViewModel ();
 label.SetBinding<PersonViewModel> (Label.TextProperty, vm => vm.Name, mode: BindingMode.OneWayToSource);
     
 viewmodel.Name = "John Doe";
-Debug.WriteLine (label.Text); //prints "John Doe"
+Debug.WriteLine (label.Text); //prints ""
 label.Text = "Foo";
 Debug.WriteLine (viewmodel.Name); //prints "Foo"
     ]]></code>

--- a/docs/Xamarin.Forms/BindingMode.xml
+++ b/docs/Xamarin.Forms/BindingMode.xml
@@ -60,7 +60,7 @@ label.BindingContext = viewmodel = new PersonViewModel ();
 label.SetBinding<PersonViewModel> (Label.TextProperty, vm => vm.Name, mode: BindingMode.OneWayToSource);
     
 viewmodel.Name = "John Doe";
-Debug.WriteLine (label.Text); //prints ""
+Debug.WriteLine (label.Text); //prints "John Doe"
 label.Text = "Foo";
 Debug.WriteLine (viewmodel.Name); //prints "Foo"
     ]]></code>


### PR DESCRIPTION
Changed `Debug.Writeline(label.Text); //prints ""` to `Debug.Writeline(label.Text); //prints "John Doe"`