### PR TITLE
Font family semantics

### DIFF
--- a/docs/Xamarin.Forms/Label.xml
+++ b/docs/Xamarin.Forms/Label.xml
@@ -224,7 +224,7 @@ public class App : Application
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the font family to which the font for the label belongs.</summary>
-        <value>The font family, or null for the platforms's default font family.</value>
+        <value>The font family, or null for the platform default font family.</value>
         <remarks>The font family can refer to a system font or a <a href="https://docs.microsoft.com/en-us/xamarin/xamarin-forms/user-interface/text/fonts#use-a-custom-font">custom font</a>.</remarks>
       </Docs>
     </Member>

--- a/docs/Xamarin.Forms/Label.xml
+++ b/docs/Xamarin.Forms/Label.xml
@@ -223,9 +223,9 @@ public class App : Application
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets the font family to which the font for the label belongs.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets or sets the font family to which the font for the label belongs.</summary>
+        <value>The font family, or null for the platforms's default font family.</value>
+        <remarks>The font family can refer to a system font or a <a href="https://docs.microsoft.com/en-us/xamarin/xamarin-forms/user-interface/text/fonts#use-a-custom-font">custom font</a>.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FontFamilyProperty">


### PR DESCRIPTION
Documents the meaning of null. Also refers to concept doc regarding system and custom fonts. There might be a better way than `<a href...` to make the reference - maybe a `<see...`.