### PR TITLE
Typo fixed

### DIFF
--- a/docs/Xamarin.Forms/ContentPage.xml
+++ b/docs/Xamarin.Forms/ContentPage.xml
@@ -28,7 +28,7 @@
     <remarks>
       <para>This is a Page displaying a single View, often a container like a <see cref="T:Xamarin.Forms.StackLayout" /> or <see cref="T:Xamarin.Forms.ScrollView" />.</para>
       <example>
-        <para>The example below is taken from he App.cs file that is contained in the default "Hello, Forms!" app. It  uses a <see cref="T:Xamarin.Forms.ContentPage" /> to display a label, which is a typical, though basic, use of the <see cref="T:Xamarin.Forms.ContentPage" /> class.</para>
+        <para>The example below is taken from the App.cs file that is contained in the default "Hello, Forms!" app. It  uses a <see cref="T:Xamarin.Forms.ContentPage" /> to display a label, which is a typical, though basic, use of the <see cref="T:Xamarin.Forms.ContentPage" /> class.</para>
         <code lang="csharp lang-csharp"><![CDATA[
 using System;
 using Xamarin.Forms;


### PR DESCRIPTION
"The example below is taken from **he** App.cs" (he) => "The example below is taken from **the** App.cs"
-Added a missing letter ("**t**he")