### PR TITLE
Fix typos in VisualElement Behaviors property

### DIFF
--- a/docs/Xamarin.Forms/VisualElement.xml
+++ b/docs/Xamarin.Forms/VisualElement.xml
@@ -325,7 +325,7 @@
         <ReturnType>System.Collections.Generic.IList&lt;Xamarin.Forms.Behavior&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets the list of Behavior associated to this element. This is a bindable propery.</summary>
+        <summary>Gets the list of Behaviors associated to this element. This is a bindable property.</summary>
         <value>
         </value>
         <remarks>To be added.</remarks>


### PR DESCRIPTION
"Behavior" -> "Behaviors"
"propery" -> "property"
Fixes #175