### PR TITLE
Added related Configuration information in Xamarin.Forms.Maps Namespace doc 

### DIFF
--- a/docs/ns-Xamarin.Forms.Maps.xml
+++ b/docs/ns-Xamarin.Forms.Maps.xml
@@ -53,6 +53,7 @@ namespace HelloMap.Android
 }
           ]]></code>
       </example>
-    </remarks>
+    </remarks>   
+	<related type="article" href="https://docs.microsoft.com/xamarin/xamarin-forms/user-interface/map/setup">Xamarin.Forms Map Initialization and Configuration</related>
   </Docs>
 </Namespace>


### PR DESCRIPTION
There is a detailed document with Map initialization and configuration information. In the definition of the Map namespace, this PR adds a link to that documentation.

fix #152 