### PR TITLE
Fix rendering error

### DIFF
--- a/docs/Xamarin.Forms/ContentPropertyAttribute.xml
+++ b/docs/Xamarin.Forms/ContentPropertyAttribute.xml
@@ -29,7 +29,6 @@
       <para>XAML processor uses to determine the content property.</para>
       <para>
 Decorating types with ContentPropertyAttribute allows shorter XAML syntax. As </para>
-      <example>
         <see cref="T:Xamarin.Forms.ContentView" /> has a ContentProperty attribute applied, this XAML is valid:
 <code lang="csharp lang-csharp"><![CDATA[
 <ContentView>
@@ -43,7 +42,7 @@ This is equivalent to the following, more explicit XAML
     <Label Text="Hello, Forms"/>
   </ContentView.Content>
 </ContentView>
-  ]]></code></example>
+  ]]></code>
     </remarks>
   </Docs>
   <Members>


### PR DESCRIPTION
Removed the `<example>` tag to fix the rendering error that's adding a `</div>` to the end of the second code example:

![MicrosoftTeams-image6dc653c778df94a0d608e18f11f97d478a24e6486a39847e7f0bc4b7c0e2a061](https://user-images.githubusercontent.com/8092460/102991962-37090d00-4512-11eb-962d-297ba5b11c58.png)
