### PR TITLE
Add remarks to clarify SetBackButtonTitle usage

### DIFF
--- a/docs/Xamarin.Forms/NavigationPage.xml
+++ b/docs/Xamarin.Forms/NavigationPage.xml
@@ -1156,7 +1156,7 @@
         <param name="page">To be added.</param>
         <param name="value">To be added.</param>
         <summary>Sets the title that appears on the back button for <paramref name="page" />.</summary>
-        <remarks>To be added.</remarks>
+        <remarks>The back button title is set from the <paramref name="page" /> that is being navigated back to and is accessible from the page being navigated back from.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetHasBackButton">


### PR DESCRIPTION
Add remarks to clarify SetBackButtonTitle usage as `SetBackButtonTitle` usage can be confusing

https://github.com/xamarin/Xamarin.Forms/issues/8701#issuecomment-768937090

