### PR TITLE
[BULK] DocuTune - Fix build validation issues: docs-link-absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains the source of the Xamarin.Forms API documentation to be edited.
 
-An example URL to start browsing [here](/dotnet/api/xamarin.forms)
+An example URL to start browsing is [here](/dotnet/api/xamarin.forms).
 
 ## Microsoft Open Source Code of Conduct
 


### PR DESCRIPTION
[BULK UPDATE] DocuTune - Fix build validation issues: docs-link-absolute

**Global effort to fix build validation errors**

The Microsoft Skilling team is fixing build validation errors and specific brand inconsistencies in Microsoft technical documentation for the rest of FY23 Q1. This will help address various accessibility, security, and usability issues. This PR was generated using DocuTune. It includes only targeted fixes and minor formatting adjustments.

DocuTune PRs improve quality of technical content by finding and automatically correcting a broad set of issues only where the correction is suitable. Please review within five business days and merge or comment in the PR with any changes you'd like to see. Thank you!

CorrelationId: 0df9c2d6-63f8-4d1e-8b57-b33611a06514
InitiativeId: docutune-build-validation-issues-2022-05
PointOfContact: Alex Buck
