### PR TITLE
Remove typo in Color.xml

### DIFF
--- a/docs/Xamarin.Forms/Color.xml
+++ b/docs/Xamarin.Forms/Color.xml
@@ -2777,7 +2777,7 @@
         <param name="alpha">The alpha multiplicator.</param>
         <summary>Returns a new color with the alpha channel multiplied by alpha, clamped to the inclusive range [0-1].</summary>
         <returns>A new RGBA color with a possibly new value for its alpha channel. See Remarks.</returns>
-        <remarks>The resulting color has its alpha channel clamped toto the inclusive range [0-1], preventing invalid colors.</remarks>
+        <remarks>The resulting color has its alpha channel clamped to the inclusive range [0-1], preventing invalid colors.</remarks>
       </Docs>
     </Member>
     <Member MemberName="NavajoWhite">


### PR DESCRIPTION
'To" was written twice ('toto')