### PR TITLE
Fix breadcrumbs

### DIFF
--- a/docs/XamarinFormsAPI-breadcrumb/toc.yml
+++ b/docs/XamarinFormsAPI-breadcrumb/toc.yml
@@ -1,0 +1,7 @@
+- name: Xamarin
+  tocHref: /dotnet/
+  topicHref: /xamarin/index
+  items:
+  - name: .NET API browser
+    tocHref: /dotnet/
+    topicHref: /dotnet/api/index

--- a/docs/breadcrumb/toc.yml
+++ b/docs/breadcrumb/toc.yml
@@ -1,2 +1,0 @@
-- name: Docs
-  tocHref: /

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -42,13 +42,13 @@
     },
     "globalMetadata": {
       "apiPlatform": "dotnet",
-      "breadcrumb_path": "~/breadcrumb/toc.yml",
+      "breadcrumb_path": "/dotnet/XamarinFormsAPI-breadcrumb/toc.json",
       "author": "dotnet-bot",
       "ms.author": "dotnetcontent",
       "manager": "crdun",
       "ms.date": "03/13/2019",
       "searchScope": ["Xamarin.Forms API"],
-      "uhfHeaderId": "MSDocsHeader-DotNet",
+      "uhfHeaderId": "MSDocsHeader-Xamarin",
       "ms.topic": "managed-reference",
       "ms.prod": "xamarin",
       "ms.technology":"xamarin-forms"


### PR DESCRIPTION
This PR brings breadcrumb implementation into alignment with [platform architecture requirements](https://review.learn.microsoft.com/en-us/help/platform/navigation-overview?branch=main#requirements-for-content-ecosystems). This PR is part of a previously announced batch of breadcrumb fixes across the Learn platform and will be auto-merged if there are no build warnings and if PR Automerger service is available for this repo. This PR may include removing the “extend breadcrumb” feature from any docfx files that are still using it, fixing breadcrumb file references in the docfx file, and rewriting breadcrumb files to match the [approved breadcrumb pattern](https://review.learn.microsoft.com/en-us/help/platform/navigation-breadcrumbs-overview?branch=main#breadcrumbs-in-documentation) for a given product’s documentation. 

note: also updated uhfHeaderId to show Xamarin L2 header instead of .NET.